### PR TITLE
Implement locking on Windows (issue #34)

### DIFF
--- a/ruruki/locks.py
+++ b/ruruki/locks.py
@@ -6,7 +6,7 @@ import os.path
 from ruruki import interfaces
 
 if os.name == 'nt':
-    import msvcrt
+    import msvcrt    # pylint: disable=import-error
 else:
     import fcntl
 

--- a/ruruki/locks.py
+++ b/ruruki/locks.py
@@ -3,8 +3,12 @@ Classes for handling locking and ownerships.
 """
 import os
 import os.path
-import fcntl
 from ruruki import interfaces
+
+if os.name == 'nt':
+    import msvcrt
+else:
+    import fcntl
 
 
 class Lock(interfaces.ILock):
@@ -68,10 +72,12 @@ class FileLock(Lock):
         self._fd = None
 
     def acquire(self):
-        self._fd = open(self.filename, "w")
-
         try:
-            fcntl.flock(self._fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            self._fd = open(self.filename, "w")
+            if os.name == 'nt':
+                msvcrt.locking(self._fd.fileno(), msvcrt.LK_NBLCK, -1)
+            else:
+                fcntl.flock(self._fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except IOError:
             raise interfaces.AcquireError(
                 "Failed acquiring a lock on {0!r}.".format(self.filename)

--- a/ruruki/tests/test_locks.py
+++ b/ruruki/tests/test_locks.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-docstring
 import os.path
+import sys
 import tempfile
 import unittest
 from ruruki import interfaces
@@ -143,6 +144,7 @@ class TestDirectoryLock(unittest.TestCase):
             self.lock.release,
         )
 
+    @unittest.skipIf(os.name == "nt", "Windows won't allow that")
     def test_release_file_not_found(self):
         self.lock.acquire()
         os.remove(self.lock.filename)

--- a/ruruki/tests/test_locks.py
+++ b/ruruki/tests/test_locks.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-docstring
 import os.path
-import sys
+import os
 import tempfile
 import unittest
 from ruruki import interfaces


### PR DESCRIPTION
It makes more test pass, but starts to fail after [test_locks::test_release_file_not_found](https://github.com/optiver/ruruki/blob/3dd57b0ac416aa467a3612aa032c8a914b861b59/ruruki/tests/test_locks.py#L148), which attempts to remove lock file before releasing the lock. Because Windows implements mandatory locking, this operation fails.

The question is if ruruki really needs this feature and why?