### PR TITLE
Fix TestFileLock.test_acquire for Windows

### DIFF
--- a/ruruki/tests/test_locks.py
+++ b/ruruki/tests/test_locks.py
@@ -108,11 +108,11 @@ class TestFileLock(unittest.TestCase):
         self.assertEqual(self.lock.locked, False)
 
     def test_enter_contex_manager(self):
-        with locks.FileLock(self.filename.name) as lock:
+        with locks.FileLock(self.filename) as lock:
             self.assertEqual(lock.locked, True)
 
     def test_exit_contex_manager(self):
-        context_manager = locks.FileLock(self.filename.name)
+        context_manager = locks.FileLock(self.filename)
         lock = context_manager.__enter__()
         lock.__exit__(None, None, None)
         self.assertEqual(lock.locked, False)

--- a/ruruki/tests/test_locks.py
+++ b/ruruki/tests/test_locks.py
@@ -55,12 +55,21 @@ class TestBaseLock(unittest.TestCase):
 
 class TestFileLock(unittest.TestCase):
     def setUp(self):
-        self.filename = tempfile.NamedTemporaryFile()
-        self.lock = locks.FileLock(self.filename.name)
+        self.tmpfile = tempfile.NamedTemporaryFile(delete=False)
+        self.filename = self.tmpfile.name
+        # on Windows the file can not be open second time, which
+        # what FileLock does
+        self.tmpfile.close()
+        self.lock = locks.FileLock(self.filename)
+
+    def tearDown(self):
+        os.remove(self.filename)
 
     def test_acquire(self):
         self.lock.acquire()
         self.assertEqual(self.lock.locked, True)
+        # so that file can be safely removed on Windows
+        self.lock.release()
 
     def test_acquire_flock_error(self):
         filename = tempfile.NamedTemporaryFile()


### PR DESCRIPTION
NamedTemporaryFile can not be opened second time on Windows
https://docs.python.org/2/library/tempfile.html#tempfile.NamedTemporaryFile
and that's why the test fails here.

Do you relly need to lock open file? In that case FileLock API needs to be changed to accept opened file descriptor instead of opening own.

```
======================================================================
ERROR: test_acquire (ruruki.tests.test_locks.TestFileLock)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\ruruki\ruruki\tests\test_locks.py", line 62, in test_acquire
    self.lock.acquire()
  File "C:\ruruki\ruruki\locks.py", line 76, in acquire
    self._fd = open(self.filename, "w")
IOError: [Errno 13] Permission denied: 'c:\\users\\user\\appdata\\local\\temp2\\tmpnd7h77'
```