### PR TITLE
Nosereports

### DIFF
--- a/ruruki/tests/test_locks.py
+++ b/ruruki/tests/test_locks.py
@@ -108,11 +108,11 @@ class TestFileLock(unittest.TestCase):
         self.assertEqual(self.lock.locked, False)
 
     def test_enter_contex_manager(self):
-        with locks.FileLock(self.filename.name) as lock:
+        with locks.FileLock(self.filename) as lock:
             self.assertEqual(lock.locked, True)
 
     def test_exit_contex_manager(self):
-        context_manager = locks.FileLock(self.filename.name)
+        context_manager = locks.FileLock(self.filename)
         lock = context_manager.__enter__()
         lock.__exit__(None, None, None)
         self.assertEqual(lock.locked, False)

--- a/ruruki/tests/test_locks.py
+++ b/ruruki/tests/test_locks.py
@@ -55,12 +55,21 @@ class TestBaseLock(unittest.TestCase):
 
 class TestFileLock(unittest.TestCase):
     def setUp(self):
-        self.filename = tempfile.NamedTemporaryFile()
-        self.lock = locks.FileLock(self.filename.name)
+        self.tmpfile = tempfile.NamedTemporaryFile(delete=False)
+        self.filename = self.tmpfile.name
+        # on Windows the file can not be open second time, which
+        # what FileLock does
+        self.tmpfile.close()
+        self.lock = locks.FileLock(self.filename)
+
+    def tearDown(self):
+        os.remove(self.filename)
 
     def test_acquire(self):
         self.lock.acquire()
         self.assertEqual(self.lock.locked, True)
+        # so that file can be safely removed on Windows
+        self.lock.release()
 
     def test_acquire_flock_error(self):
         filename = tempfile.NamedTemporaryFile()

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,8 @@ deps=nose
      assertpy
      pylint
 commands=
-    nosetests -c {toxinidir}/setup.cfg --cover-html-dir={envdir}/coverage --cover-package=ruruki ruruki
+    nosetests -c "{toxinidir}/setup.cfg" --cover-html-dir="{envdir}/coverage" --cover-package=ruruki \
+        --with-xunit --xunit-file="{envdir}/nosetests.xml" ruruki
     behave {toxinidir}/ruruki/test_behave
     pylint -d I,W --rcfile={toxinidir}/.pylintrc ruruki
 


### PR DESCRIPTION
Quoting paths to prevent them from failure on paths with quotes, and produce test report in xunit format, which can be then parsed