### PR TITLE
Update Travis CI config

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -338,7 +338,7 @@ max-branches=12
 max-statements=50
 
 # Maximum number of parents for a class (see R0901).
-max-parents=7
+max-parents=9
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
   - 3.3
   - 3.4
   - 3.5
+  - 3.5-dev
+  - 3.6-dev
+  - nightly
 install:
   - pip install coveralls
   - pip install tox-travis
@@ -12,6 +15,10 @@ matrix:
     - python: 3.5
       env:
       - TOXENV=docs
+  allow_failures:
+    - python: 3.5-dev
+    - python: 3.6-dev
+    - python: nightly
 script:
   - mkdir docs/_static
   - tox -e ${TOXENV:-py${TRAVIS_PYTHON_VERSION/./}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,20 @@
 language: python
+python:
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
 install:
   - pip install coveralls
   - pip install tox-travis
 matrix:
   include:
-    - python: 2.7
-      env:
-      - TOXENV=py27
-    - python: 3.3
-      env:
-      - TOXENV=py33
-    - python: 3.4
-      env:
-      - TOXENV=py34
-    - python: 3.5
-      env:
-      - TOXENV=py35
     - python: 3.5
       env:
       - TOXENV=docs
 script:
   - mkdir docs/_static
-  - tox
+  - tox -e ${TOXENV:-py${TRAVIS_PYTHON_VERSION/./}}
 after_success: coveralls
 addons:
     code_climate:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,16 @@
 [tox]
-envlist = py{27,33,34,35},docs
+envlist = py{27,33,34,35},py{35,36,37}-dev,docs
+skip_missing_interpreters = True
 
 [testenv]
+basepython =
+    py27: python2.7
+    py33: python3.3
+    py34: python3.4
+    py35: python3.5
+    py36: python3.6
+    py37: python3.7
+
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 usedevelop = False
 setenv=PYTHONHASHSEED=0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34,35},py{35,36,37}-dev,docs
+envlist = py{27,33,34,35,nightly},py{35,36}-dev,docs
 skip_missing_interpreters = True
 
 [testenv]
@@ -9,7 +9,7 @@ basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
-    py37: python3.7
+    pynightly: python3.7
 
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 usedevelop = False


### PR DESCRIPTION
As per the commits below, this should make it easier to add new Python versions for testing (just add a line per version, no need to construct the build matrix) and also gives us visibility of compatibility with future releases of Python.

Change to the `.pylintrc` file ensures we start with a clean bill of health when merged.

Does not avoid the need to keep `.travis.yml` and `tox.ini` in sync.