### PR TITLE
chore: added python3.10+ support

### DIFF
--- a/ruruki/interfaces.py
+++ b/ruruki/interfaces.py
@@ -2,7 +2,14 @@
 Database interfaces.
 """
 import abc
-from collections import MutableSet
+
+try:
+    # Python 3.10+
+    from collections.abc import MutableSet
+except ImportError:
+    # Python 3.10-
+    from collections import MutableSet
+
 from collections import namedtuple
 
 


### PR DESCRIPTION
- Updated interfaces to support python3.10+ version
- Fixed issue running with Python3.10+ "ImportError: cannot import name 'MutableSet' from 'collections'"